### PR TITLE
[RFC] Crates swapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ transformable_channels = "^0.1"
 log = "^0.3"
 taxonomy_mock = { path = "./taxonomy_mock/" }
 transformable_channels_mock = { path = "./transformable_channels_mock/" }
+
+[dev-dependencies]
+stainless = "0.1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ openzwave-stateful = { git = "https://github.com/fxbox/openzwave-stateful-rust" 
 foxbox_taxonomy = { git = "https://github.com/fxbox/taxonomy.git", rev = "c222794d238072920857fea55e55d522ae75c192" }
 transformable_channels = "^0.1"
 log = "^0.3"
+taxonomy_mock = { path = "./taxonomy_mock/" }
+transformable_channels_mock = { path = "./transformable_channels_mock/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "openzwave-adapter"
 version = "0.1.0"
 authors = ["Julien Wajsberg <felash@gmail.com>"]
 
+[features]
+mock = []
+
 [dependencies]
 openzwave-stateful = { git = "https://github.com/fxbox/openzwave-stateful-rust" }
 foxbox_taxonomy = { git = "https://github.com/fxbox/taxonomy.git", rev = "c222794d238072920857fea55e55d522ae75c192" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,16 @@
 extern crate openzwave_stateful as openzwave;
-extern crate foxbox_taxonomy as taxonomy;
-extern crate transformable_channels;
+
+// #[cfg(test)]
+extern crate taxonomy_mock as taxonomy;
+// #[cfg(not(test))]
+// extern crate foxbox_taxonomy as taxonomy;
+
+
+// #[cfg(not(test))]
+// extern crate transformable_channels;
+// #[cfg(test)]
+extern crate transformable_channels_mock as transformable_channels;
+
 #[macro_use]
 extern crate log;
 
@@ -413,4 +423,3 @@ mod tests {
     fn it_works() {
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![feature(plugin)]
+#![cfg_attr(test, plugin(stainless))]
+
 #[cfg(feature = "mock")] extern crate taxonomy_mock as taxonomy;
 #[cfg(not(feature = "mock"))] extern crate foxbox_taxonomy as taxonomy;
 
@@ -410,5 +413,20 @@ impl taxonomy::adapter::Adapter for OpenzwaveAdapter {
 
             (id, value_result)
         }).collect()
+    }
+}
+
+
+#[cfg(test)]
+describe! library_unit_test {
+    before_each {
+        use taxonomy::adapter::AdapterManagerHandleImpl;
+        use std::sync::Arc;
+    }
+
+    it "should init" {
+        let m = AdapterManagerHandleImpl;
+        let arc = Arc::new(m);
+        let adapter = OpenzwaveAdapter::init(&arc).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,11 @@
+#[cfg(feature = "mock")] extern crate taxonomy_mock as taxonomy;
+#[cfg(not(feature = "mock"))] extern crate foxbox_taxonomy as taxonomy;
+
+#[cfg(not(feature = "mock"))] extern crate transformable_channels;
+#[cfg(feature = "mock")] extern crate transformable_channels_mock as transformable_channels;
+
+
 extern crate openzwave_stateful as openzwave;
-
-// #[cfg(test)]
-extern crate taxonomy_mock as taxonomy;
-// #[cfg(not(test))]
-// extern crate foxbox_taxonomy as taxonomy;
-
-
-// #[cfg(not(test))]
-// extern crate transformable_channels;
-// #[cfg(test)]
-extern crate transformable_channels_mock as transformable_channels;
 
 #[macro_use]
 extern crate log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,10 +412,3 @@ impl taxonomy::adapter::Adapter for OpenzwaveAdapter {
         }).collect()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-    }
-}

--- a/taxonomy_mock/Cargo.toml
+++ b/taxonomy_mock/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "taxonomy_mock"
+version = "0.1.0"
+
+[dependencies]
+transformable_channels_mock = { path = "../transformable_channels_mock/"}

--- a/taxonomy_mock/src/lib.rs
+++ b/taxonomy_mock/src/lib.rs
@@ -1,0 +1,198 @@
+#![allow(dead_code)]
+
+extern crate transformable_channels_mock;
+
+pub mod util {
+    use std::marker::PhantomData;
+    use std::hash::{ Hash, Hasher };
+
+    #[derive(Debug, Clone)]
+    pub struct Id<T> {
+        phantom: PhantomData<T>,
+    }
+
+    impl<T> Id<T> {
+        pub fn new(_: &str) -> Self {
+            Id {
+                phantom: PhantomData,
+            }
+        }
+    }
+    impl<T> PartialEq for Id<T> {
+        fn eq(&self, _: &Self) -> bool {
+            return true;
+        }
+    }
+    impl<T> Eq for Id<T> {}
+
+    impl<T> Hash for Id<T> {
+        fn hash<H>(&self, _: &mut H) where H: Hasher {}
+    }
+
+    pub struct TagId;
+}
+
+pub mod services {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[derive(Clone)]
+    pub struct Setter {
+        pub kind: ChannelKind,
+        pub updated: Option<values::TimeStamp>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct Getter {
+        pub kind: ChannelKind,
+        pub updated: Option<values::TimeStamp>,
+    }
+
+    #[derive(Clone)]
+    pub struct AdapterId;
+
+    #[derive(Clone)]
+    pub struct ServiceId;
+    pub struct Service;
+
+    impl Service {
+        pub fn empty(_: util::Id<ServiceId>, _: util::Id<AdapterId>) -> Service {
+            Service
+        }
+    }
+
+    pub trait IOMechanism {}
+
+    pub struct Channel<IOMechanism> {
+        pub tags: HashSet<util::Id<util::TagId>>,
+        pub id: util::Id<IOMechanism>,
+        pub service: util::Id<ServiceId>,
+        pub mechanism: IOMechanism,
+        pub adapter: util::Id<AdapterId>,
+        pub last_seen: Option<values::TimeStamp>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub enum ChannelKind {
+        Ready,
+        OpenClosed
+    }
+}
+
+pub mod values {
+    pub enum Value {
+        OpenClosed(OpenClosed),
+        Unit
+    }
+
+    pub enum Type {
+        OpenClosed
+    }
+    pub enum OpenClosed {
+        Open,
+        Closed
+    }
+    pub enum Range {}
+
+    #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+    pub struct TimeStamp;
+}
+
+pub mod api {
+    use super::*;
+    use std::collections::HashMap;
+    use std::{ fmt, error };
+
+    #[derive(Debug)]
+    pub enum Error {
+        InternalError(InternalError)
+    }
+
+    impl fmt::Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "stubbed error")
+        }
+    }
+
+    impl error::Error for Error {
+        fn description(&self) -> &str {
+            return "stubbed error"
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum InternalError {
+        NoSuchGetter(util::Id<services::Getter>)
+    }
+    pub struct User;
+    pub type ResultMap<K, T, E> = HashMap<K, Result<T, E>>;
+}
+
+pub mod adapter {
+    use transformable_channels_mock::mpsc::ExtSender;
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    pub trait AdapterManagerHandle {
+        fn add_adapter(& self, adapter: Arc<Adapter>) -> Result<(), api::Error>;
+        fn remove_adapter(& self, id: &util::Id<services::AdapterId>) -> Result<(), api::Error>;
+        fn add_service(& self, service: services::Service) -> Result<(), api::Error>;
+        fn remove_service(& self, service_id: &util::Id<services::ServiceId>) -> Result<(), api::Error>;
+        fn add_getter(& self, setter: services::Channel<services::Getter>) -> Result<(), api::Error>;
+        fn remove_getter(& self, id: &util::Id<services::Getter>) -> Result<(), api::Error>;
+        fn add_setter(& self, setter: services::Channel<services::Setter>) -> Result<(), api::Error>;
+        fn remove_setter(& self, id: &util::Id<services::Setter>) -> Result<(), api::Error>;
+    }
+
+    pub struct AdapterManagerHandleImpl;
+    impl AdapterManagerHandle for AdapterManagerHandleImpl {
+        fn add_adapter(& self, _: Arc<Adapter>) -> Result<(), api::Error> {
+            Ok(())
+        }
+        fn remove_adapter(& self, _: &util::Id<services::AdapterId>) -> Result<(), api::Error> {
+            Ok(())
+        }
+        fn add_service(& self, _: services::Service) -> Result<(), api::Error> {
+            Ok(())
+        }
+        fn remove_service(& self, _: &util::Id<services::ServiceId>) -> Result<(), api::Error> {
+            Ok(())
+        }
+        fn add_getter(& self, _: services::Channel<services::Getter>) -> Result<(), api::Error> {
+            Ok(())
+        }
+        fn remove_getter(& self, _: &util::Id<services::Getter>) -> Result<(), api::Error> {
+            Ok(())
+        }
+        fn add_setter(& self, _: services::Channel<services::Setter>) -> Result<(), api::Error> {
+            Ok(())
+        }
+        fn remove_setter(& self, _: &util::Id<services::Setter>) -> Result<(), api::Error> {
+            Ok(())
+        }
+    }
+
+    pub trait AdapterWatchGuard {}
+
+    pub trait Adapter {
+        fn id(&self) -> super::util::Id<super::services::AdapterId>;
+        fn name(&self) -> &str;
+        fn vendor(&self) -> &str;
+        fn version(&self) -> &[u32; 4];
+        fn fetch_values(&self, mut set: Vec<util::Id<services::Getter>>, _: api::User) -> api::ResultMap<util::Id<services::Getter>, Option<values::Value>, api::Error>;
+        fn send_values(&self, values: HashMap<util::Id<services::Setter>, values::Value>, _: api::User) -> api::ResultMap<util::Id<services::Setter>, (), api::Error>;
+        fn register_watch(&self, mut values: Vec<(util::Id<services::Getter>, Option<values::Range>)>, sender: Box<ExtSender<WatchEvent>>) -> api::ResultMap<util::Id<services::Getter>, Box<AdapterWatchGuard>, api::Error>;
+    }
+    pub enum WatchEvent {
+        Enter {
+            id: util::Id<services::Getter>,
+            value: values::Value
+        },
+
+        Exit {
+            id: util::Id<services::Getter>,
+            value: values::Value
+        }
+    }
+}

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,15 +1,22 @@
+#![feature(plugin)]
+#![cfg_attr(test, plugin(stainless))]
+
+
 extern crate taxonomy_mock as taxonomy;
 extern crate openzwave_adapter;
 
-use openzwave_adapter::OpenzwaveAdapter;
-use taxonomy::adapter::AdapterManagerHandleImpl;
+#[cfg(test)]
+describe! library {
+    before_each {
+        use openzwave_adapter::OpenzwaveAdapter;
+        use taxonomy::adapter::AdapterManagerHandleImpl;
 
-use std::sync::Arc;
+        use std::sync::Arc;
+    }
 
-#[test]
-fn test_init() {
-    let m = AdapterManagerHandleImpl;
-    let arc = Arc::new(m);
-    let adapter = OpenzwaveAdapter::init(&arc);
-    assert!(true);
+    it "should init" {
+        let m = AdapterManagerHandleImpl;
+        let arc = Arc::new(m);
+        let adapter = OpenzwaveAdapter::init(&arc).unwrap();
+    }
 }

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,0 +1,15 @@
+extern crate taxonomy_mock as taxonomy;
+extern crate openzwave_adapter;
+
+use openzwave_adapter::OpenzwaveAdapter;
+use taxonomy::adapter::AdapterManagerHandleImpl;
+
+use std::sync::Arc;
+
+#[test]
+fn test_init() {
+    let m = AdapterManagerHandleImpl;
+    let arc = Arc::new(m);
+    let adapter = OpenzwaveAdapter::init(&arc);
+    assert!(true);
+}

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -6,7 +6,7 @@ extern crate taxonomy_mock as taxonomy;
 extern crate openzwave_adapter;
 
 #[cfg(test)]
-describe! library {
+describe! library_integration_test {
     before_each {
         use openzwave_adapter::OpenzwaveAdapter;
         use taxonomy::adapter::AdapterManagerHandleImpl;

--- a/transformable_channels_mock/Cargo.toml
+++ b/transformable_channels_mock/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "transformable_channels_mock"
+version = "0.1.0"

--- a/transformable_channels_mock/src/lib.rs
+++ b/transformable_channels_mock/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod mpsc {
+    pub trait ExtSender<T>: Send + 'static where T: Send + 'static {
+        fn send(&self, t: T) -> Result<(), ()>;
+    }
+}


### PR DESCRIPTION
Usage: `cargo test --features "mock"`.

The `openzwave-rust` crate is not mocked yet. The only ones are `taxonomy` and `transformable_channels`.

What are your first impressions, @julienw ?
